### PR TITLE
Specifiy we want JSON format

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -23,7 +23,7 @@ async function getRelevantFiles(task, summaries) {
     Your TASK: ${task}
     Identify the main files in the existing codebase that are relevant to your TASK. If you want to create a new file, don't include it in the output.
     For each file explain also what is relevant in this file to complete the TASK.
-    Use the following format:
+    Use the following JSON format:
     \`\`\`
     [{"path": "<insert file name and path>", "context": "<insert context>"},{"path": "<insert file and path>", "context": "<insert context>"}]
     \`\`\`


### PR DESCRIPTION
This prevents the AI/LLM/GPT from being silly,
specifically, I ran this on Windows OS and it decided to use a single `\` for paths which breaks JSON.

sounds like a good idea in general for it to know it should try for valid JSON format and not just this special case format provided.