### PR TITLE
cleanup autopilot paths

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,7 +7,7 @@ CODE_DIR=./
 
 # What files do you want to process?
 FILE_EXTENSIONS_TO_PROCESS=.js,.tsx,.ts,.jsx
-IGNORE_LIST=node_modules,autopilot,coverage,public,__tests__
+IGNORE_LIST=node_modules,coverage,public,__tests__
 
 # Currently all the models support either 'gpt-3.5-turbo' or 'gpt-4' (if you have access to it)
 ADVANCED_MODEL=gpt-4 # Recommanded

--- a/createSummaryOfFiles.js
+++ b/createSummaryOfFiles.js
@@ -135,7 +135,7 @@ async function main() {
   }
   // Watch for file changes in the directory
   const watcher = chokidar.watch(directoryPath, {
-    ignored: /node_modules|autopilot|helpers/,
+    ignored: /node_modules|helpers/,
     persistent: true,
     ignoreInitial: true,
   });


### PR DESCRIPTION
These were used with the old autopilot system, but are no longer needed. We used to recommend people put autopilot inside their code directory, but now we recommend they just configure CODE_DIR.